### PR TITLE
adapted some includes to fit IWYU's pattern

### DIFF
--- a/Source/Blu/Private/BluPrivatePCH.h
+++ b/Source/Blu/Private/BluPrivatePCH.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "CoreUObject.h"
-#include "Engine.h"
+#include "Engine/Engine.h"
 #include "Engine/Console.h"
 #include "Runtime/UMG/Public/UMG.h"
 #include "Runtime/UMG/Public/UMGStyle.h"
@@ -10,7 +10,7 @@
 
 // You should place include statements to your module's private header files here.  You only need to
 // add includes for headers that are used in most of your module's source files though.
-#include "ModuleManager.h"
+#include "Modules/ModuleManager.h"
 #include "IBlu.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogBlu, Log, All);

--- a/Source/Blu/Public/BluManager.h
+++ b/Source/Blu/Public/BluManager.h
@@ -24,12 +24,12 @@ class BLU_API BluManager : public CefApp
 
 	public:
 
-		BluManager();
+	BluManager();
 
-		static void doBluMessageLoop();
-		static CefSettings settings;
-		static CefMainArgs main_args;
-		static bool CPURenderSettings;
+	static void doBluMessageLoop();
+	static CefSettings settings;
+	static CefMainArgs main_args;
+	static bool CPURenderSettings;
 
 	virtual void OnBeforeCommandLineProcessing(const CefString& process_type,
 			CefRefPtr< CefCommandLine > command_line) override;

--- a/Source/Blu/Public/BluManager.h
+++ b/Source/Blu/Public/BluManager.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #if PLATFORM_WINDOWS
-#include "WindowsHWrapper.h"
-#include "AllowWindowsPlatformTypes.h"
-#include "AllowWindowsPlatformAtomics.h"
+#include "Windows/WindowsHWrapper.h"
+#include "Windows/AllowWindowsPlatformTypes.h"
+#include "Windows/AllowWindowsPlatformAtomics.h"
 #endif
 //#pragma push_macro("OVERRIDE")
 //#undef OVERRIDE // cef headers provide their own OVERRIDE macro
@@ -14,8 +14,8 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 //#pragma pop_macro("OVERRIDE")
 #if PLATFORM_WINDOWS
-#include "HideWindowsPlatformAtomics.h"
-#include "HideWindowsPlatformTypes.h"
+#include "Windows/HideWindowsPlatformAtomics.h"
+#include "Windows/HideWindowsPlatformTypes.h"
 #endif
 
 
@@ -24,12 +24,12 @@ class BLU_API BluManager : public CefApp
 
 	public:
 
-	BluManager();
+		BluManager();
 
-	static void doBluMessageLoop();
-	static CefSettings settings;
-	static CefMainArgs main_args;
-	static bool CPURenderSettings;
+		static void doBluMessageLoop();
+		static CefSettings settings;
+		static CefMainArgs main_args;
+		static bool CPURenderSettings;
 
 	virtual void OnBeforeCommandLineProcessing(const CefString& process_type,
 			CefRefPtr< CefCommandLine > command_line) override;

--- a/Source/Blu/Public/IBlu.h
+++ b/Source/Blu/Public/IBlu.h
@@ -2,7 +2,7 @@
 * (c) Aaron M. Shea 2014
 */
 #pragma once
-#include "ModuleManager.h"
+#include "Modules/ModuleManager.h"
 
 class IBlu : public IModuleInterface
 {

--- a/Source/Blu/Public/RenderHandler.h
+++ b/Source/Blu/Public/RenderHandler.h
@@ -3,9 +3,9 @@
 #include "BluEye.h"
 
 #if PLATFORM_WINDOWS
-#include "WindowsHWrapper.h"
-#include "AllowWindowsPlatformTypes.h"
-#include "AllowWindowsPlatformAtomics.h"
+#include "Windows/WindowsHWrapper.h"
+#include "Windows/AllowWindowsPlatformTypes.h"
+#include "Windows/AllowWindowsPlatformAtomics.h"
 #endif
 //#pragma push_macro("OVERRIDE")
 //#undef OVERRIDE // cef headers provide their own OVERRIDE macro
@@ -15,8 +15,8 @@ THIRD_PARTY_INCLUDES_START
 THIRD_PARTY_INCLUDES_END
 //#pragma pop_macro("OVERRIDE")
 #if PLATFORM_WINDOWS
-#include "HideWindowsPlatformAtomics.h"
-#include "HideWindowsPlatformTypes.h"
+#include "Windows/HideWindowsPlatformAtomics.h"
+#include "Windows/HideWindowsPlatformTypes.h"
 #endif
 
 class RenderHandler : public CefRenderHandler

--- a/Source/BluLoader/Private/BluLoaderPrivatePCH.h
+++ b/Source/BluLoader/Private/BluLoaderPrivatePCH.h
@@ -1,9 +1,9 @@
 #pragma once
 #include "CoreUObject.h"
-#include "Engine.h"
+#include "Engine/Engine.h"
 #include "Engine/Console.h"
 
-#include "ModuleManager.h"
+#include "Modules/ModuleManager.h"
 #include "IBluLoader.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogBluLoader, Log, All);

--- a/Source/BluLoader/Public/IBluLoader.h
+++ b/Source/BluLoader/Public/IBluLoader.h
@@ -2,7 +2,7 @@
 * (c) Aaron M. Shea 2014
 */
 #pragma once
-#include "ModuleManager.h"
+#include "Modules/ModuleManager.h"
 
 class IBluLoader : public IModuleInterface
 {


### PR DESCRIPTION
Hello, I was having some issues because my project uses [IWYU's](https://docs.unrealengine.com/en-US/Programming/BuildTools/UnrealBuildTool/IWYU/index.html) pattern and the compiler was getting angry because of that includes, then I just used the recommended path pattern in some includes as IWYU's guides and everything works again :). If you'd like to have this improvement, this change doesn't break or change anything and IWYU's projects can compile without any problem ;)