### PR TITLE
UE5.4-5.5 Posible Fix

### DIFF
--- a/Source/Blu/Private/BluEye.cpp
+++ b/Source/Blu/Private/BluEye.cpp
@@ -188,21 +188,16 @@ void UBluEye::TextureUpdate(const void *Buffer, FUpdateTextureRegion2D *UpdateRe
 		FPlatformMemory::Memcpy(RegionData->SrcData.GetData(), Buffer, RegionData->SrcData.Num());
 
 		ENQUEUE_RENDER_COMMAND(UpdateBLUICommand)(
-		[RegionData](FRHICommandList& CommandList)
-		{
-			for (uint32 RegionIndex = 0; RegionIndex < RegionData->NumRegions; RegionIndex++)
+			[RegionData](FRHICommandList& CommandList)
 			{
-				//NB: FORCEINLINE void RHIUpdateTexture2D(FRHITexture2D* Texture, uint32 MipIndex, const struct FUpdateTextureRegion2D& UpdateRegion, uint32 SourcePitch, const uint8* SourceData)
-				RHIUpdateTexture2D(RegionData->Texture2DResource->TextureRHI->GetTexture2D(), 0, RegionData->Regions[RegionIndex], RegionData->SrcPitch, 
-					RegionData->SrcData.GetData()
-					+ RegionData->Regions[RegionIndex].SrcY * RegionData->SrcPitch
-					+ RegionData->Regions[RegionIndex].SrcX * RegionData->SrcBpp);
-			}
+				for (uint32 RegionIndex = 0; RegionIndex < RegionData->NumRegions; RegionIndex++)
+				{
+					RHIUpdateTexture2D(RegionData->Texture2DResource->TextureRHI->GetTexture2D(), 0, RegionData->Regions[RegionIndex], RegionData->SrcPitch, RegionData->SrcData.GetData());
+				}
 
-			FMemory::Free(RegionData->Regions);
-			delete RegionData;
-		});
-
+				FMemory::Free(RegionData->Regions);
+				delete RegionData;
+			});
 	}
 	else 
 	{


### PR DESCRIPTION
I've removed 
                        + RegionData->Regions[RegionIndex].SrcY * RegionData->SrcPitch
                        + RegionData->Regions[RegionIndex].SrcX * RegionData->SrcBpp
because when debugging the RHIUpdateTexture2D in FD3D11DynamicRHI it seemed that when 
for (uint32 BlockRow = 0; BlockRow < HeightInBlocks; BlockRow++)
{
    FMemory::Memcpy(CopyDst, CopySrc, WidthInBlocks * FormatInfo.BlockBytes);
    CopySrc += SourcePitch;
    CopyDst += StagingPitch;
}

was running the last loop it's throwing AccessViolation error, so it seemed like the "array index" was shifted by one, so in removing that the code in the PR I think the for loop starts from index 0 or whatever is the equivalent in that case

probably the issue is generated by this [commit](https://github.com/EpicGames/UnrealEngine/commit/b7881548a3858f40aadbf0f10d206a68dc2ee47a#diff-20626505c3e38d9dcc54af41dc9bbe3987e0326005b5ee1ed3fcf046bc16e64a) in Epic repo